### PR TITLE
Register NCState_Child_Nav Widget

### DIFF
--- a/widgets/child_nav.php
+++ b/widgets/child_nav.php
@@ -50,3 +50,9 @@ class NCState_Child_Nav extends WP_Widget {
 		// processes widget options to be saved
 	}
 }
+
+// register NC State left nav widget
+function register_ncstate_child_nav_widget() {
+	register_widget( 'NCState_Child_Nav' );
+}
+add_action( 'widgets_init', 'register_ncstate_child_nav_widget' );


### PR DESCRIPTION
The code to register the widget was ?accidentally? removed in c7170fc6ae103eada3c223b3b08ad4fbbad53a8a

This commit makes sure that when the widget class is loaded, the widget is registered.
